### PR TITLE
Stricter warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ EXTRA_DIST = miniexpect.3
 lib_LTLIBRARIES = libminiexpect.la
 
 libminiexpect_la_SOURCES = miniexpect.c miniexpect.h
-libminiexpect_la_CFLAGS = $(PCRE2_CFLAGS) -Wall
+libminiexpect_la_CFLAGS = $(PCRE2_CFLAGS) -Wall -Wextra -Wshadow
 libminiexpect_la_LIBADD = $(PCRE2_LIBS)
 libminiexpect_la_LDFLAGS = -version-info 0:0:0
 
@@ -33,7 +33,7 @@ libminiexpect_la_LDFLAGS = -version-info 0:0:0
 noinst_PROGRAMS = example-sshpass
 
 example_sshpass_SOURCES = example-sshpass.c
-example_sshpass_CFLAGS = $(PCRE2_CFLAGS) -Wall
+example_sshpass_CFLAGS = $(PCRE2_CFLAGS) -Wall -Wextra -Wshadow
 example_sshpass_LDADD = libminiexpect.la
 
 # Tests.
@@ -45,15 +45,15 @@ check_PROGRAMS = \
 	test-multi-match
 
 test_spawn_SOURCES = test-spawn.c tests.h miniexpect.h
-test_spawn_CFLAGS = $(PCRE2_CFLAGS) -Wall
+test_spawn_CFLAGS = $(PCRE2_CFLAGS) -Wall -Wextra -Wshadow
 test_spawn_LDADD = libminiexpect.la
 
 test_ls_version_SOURCES = test-ls-version.c tests.h miniexpect.h
-test_ls_version_CFLAGS = $(PCRE2_CFLAGS) -Wall
+test_ls_version_CFLAGS = $(PCRE2_CFLAGS) -Wall -Wextra -Wshadow
 test_ls_version_LDADD = libminiexpect.la
 
 test_multi_match_SOURCES = test-multi-match.c tests.h miniexpect.h
-test_multi_match_CFLAGS = $(PCRE2_CFLAGS) -Wall
+test_multi_match_CFLAGS = $(PCRE2_CFLAGS) -Wall -Wextra -Wshadow
 test_multi_match_LDADD = libminiexpect.la
 
 # parallel-tests breaks the ability to put 'valgrind' into

--- a/miniexpect.c
+++ b/miniexpect.c
@@ -356,7 +356,7 @@ mexp_expect (mexp_h *h, const mexp_regexp *regexps,
           if (match_data)
             ovector = pcre2_get_ovector_pointer (match_data);
 
-          if (ovector != NULL && ovector[1] >= 0)
+          if (ovector != NULL && ovector[1] != ~(PCRE2_SIZE)0)
             h->next_match = ovector[1];
           else
             h->next_match = -1;

--- a/test-ls-version.c
+++ b/test-ls-version.c
@@ -56,8 +56,8 @@ main (int argc, char *argv[])
 
   switch (mexp_expect (h,
                        (mexp_regexp[]) {
-                         { 100, ls_coreutils_re },
-                         { 101, ls_busybox_re },
+                         { 100, ls_coreutils_re, 0 },
+                         { 101, ls_busybox_re, 0 },
                          { 0 },
                        }, match_data)) {
   case 100:

--- a/test-ls-version.c
+++ b/test-ls-version.c
@@ -35,7 +35,7 @@
 #include "tests.h"
 
 int
-main (int argc, char *argv[])
+main (int argc __attribute__ ((unused)), char *argv[])
 {
   mexp_h *h;
   int status, r;

--- a/test-multi-match.c
+++ b/test-multi-match.c
@@ -27,7 +27,7 @@
 #include "tests.h"
 
 int
-main (int argc, char *argv[])
+main (int argc __attribute__ ((unused)), char *argv[])
 {
   mexp_h *h;
   int status;

--- a/test-multi-match.c
+++ b/test-multi-match.c
@@ -51,11 +51,11 @@ main (int argc, char *argv[])
   for (i = 0; i < 5; ++i) {
     r = mexp_expect (h,
                      (mexp_regexp[]) {
-                       { 100, multi_re },
-                       { 101, match_re },
-                       { 102, ing_re },
-                       { 103, str_re },
-                       { 104, s_re },
+                       { 100, multi_re, 0 },
+                       { 101, match_re, 0 },
+                       { 102, ing_re, 0 },
+                       { 103, str_re, 0 },
+                       { 104, s_re, 0 },
                        { 0 },
                      }, match_data);
     switch (r) {

--- a/test-spawn.c
+++ b/test-spawn.c
@@ -27,7 +27,7 @@
 #include "tests.h"
 
 int
-main (int argc, char *argv[])
+main (int argc __attribute__ ((unused)), char *argv[])
 {
   mexp_h *h;
   int status;


### PR DESCRIPTION
I found a crash in virt-p2v. I started fixing that.

While looking at the global variable related to the crash (`v2v_version`), I noticed that some functions shadowed this global variable with an identically named function parameter. Surprisingly I found that `-Wshadow` is not enabled by either `-Wall`, or even by `-Wextra`. Anyways, I added `-Wextra -Wshadow` to virt-p2v.

Then I found that `-Wextra` caught an actual bug in the miniexpect copy in virt-p2v, and that miniexpect was a separate project.

Then I found that `-Wextra` (which had proved its usefulness, see above) would not work in miniexpect unless I tweaked the code in some other places as well.

This is why software engineering is so frustrating. You want to fix ONE crash, pull on an interesting string, and the whole frickin attic comes crashing down on you. Yay!